### PR TITLE
infra: setup aws storage for tfstate 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@ frontend/build
 
 # IDE
 .idea/
+.vscode/
+
+# Terragrunt
+**/.terragrunt-cache
+
+# Terraform
+**/.terraform
+**/*.tfstate
+**/*.tfstate.backup

--- a/infra/terraform/remote_configuration/config.tf
+++ b/infra/terraform/remote_configuration/config.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = " ~> 0.12.20"
+}

--- a/infra/terraform/remote_configuration/main.tf
+++ b/infra/terraform/remote_configuration/main.tf
@@ -1,5 +1,5 @@
-resource "aws_s3_bucket" "configuration_bucket" {
-  bucket = "tezos-link-tfstate"
+resource "aws_s3_bucket" "tfstate_storage" {
+  bucket = "tzlink-tfstate"
 
   server_side_encryption_configuration {
     rule {
@@ -14,13 +14,16 @@ resource "aws_s3_bucket" "configuration_bucket" {
   }
 
   tags = {
-      Name = "tezos-link-tfstate"
-      Environment = "all"
+    Name        = "tzlink-tfstate"
+    Project     = "tezos-link"
+    Environment = "all"
+    BuildWith   = "terraform"
+    Trigramme   = "adbo"
   }
 }
 
-resource "aws_dynamodb_table" "configuration_dynamodb_table" {
-  name           = "tezos-link-tfstate-lock"
+resource "aws_dynamodb_table" "tfstate_lock" {
+  name           = "tzlink-tfstate-lock"
   read_capacity  = 20
   write_capacity = 20
   hash_key       = "LockID"
@@ -31,7 +34,10 @@ resource "aws_dynamodb_table" "configuration_dynamodb_table" {
   }
 
   tags = {
-    Name        = "tezos-link-tfstate-lock"
+    Name        = "tzlink-tfstate-lock"
+    Project     = "tezos-link"
     Environment = "all"
+    BuildWith   = "terraform"
+    Trigramme   = "adbo"
   }
 }

--- a/infra/terraform/remote_configuration/main.tf
+++ b/infra/terraform/remote_configuration/main.tf
@@ -1,0 +1,37 @@
+resource "aws_s3_bucket" "configuration_bucket" {
+  bucket = "tezos-link-tfstate"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  tags = {
+      Name = "tezos-link-tfstate"
+      Environment = "all"
+  }
+}
+
+resource "aws_dynamodb_table" "configuration_dynamodb_table" {
+  name           = "tezos-link-tfstate-lock"
+  read_capacity  = 20
+  write_capacity = 20
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "tezos-link-tfstate-lock"
+    Environment = "all"
+  }
+}

--- a/infra/terraform/remote_configuration/provider.tf
+++ b/infra/terraform/remote_configuration/provider.tf
@@ -1,7 +1,3 @@
-terraform {
-  required_version = "0.12.20"
-}
-
 provider "aws" {
   version = "~> 2.0"
   region  = "eu-west-1"

--- a/infra/terraform/remote_configuration/terraform.tf
+++ b/infra/terraform/remote_configuration/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+    required_version = "0.12.20"
+}
+
+provider "aws" {
+  version = "~> 2.0"
+  region  = "eu-west-1"
+}

--- a/infra/terraform/remote_configuration/terraform.tf
+++ b/infra/terraform/remote_configuration/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-    required_version = "0.12.20"
+  required_version = "0.12.20"
 }
 
 provider "aws" {


### PR DESCRIPTION
- Add infra folder
- Add terraform/remote_state folder with Terraform code to generate
  - A S3 bucket
  - A dynamo_db table for the lock.
- Improve gitignore with infrastructure file and avoid pushing .vscode files.